### PR TITLE
fix: fix returning wrong values if n_end is small

### DIFF
--- a/src/jacobi_poly/_main.py
+++ b/src/jacobi_poly/_main.py
@@ -23,9 +23,9 @@ def _jacobi(
     # Compute the first two polynomials
     # https://en.wikipedia.org/wiki/Jacobi_polynomials#Special_cases
     n_end = out.shape[0]
-    if n_end >= 0:
+    if n_end > 0:
         out[0] = 1.0
-    if n_end >= 1:
+    if n_end > 1:
         out[1] = (alpha + 1) + (alpha + beta + 2) * (x - 1) / 2
 
     # Use recurrence relation to compute the rest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ from jacobi_poly import binom, gegenbauer_all, jacobi_all, legendre_all
         (3, 3, 4),
     ],
 )
-@pytest.mark.parametrize("n_end", [8])
+@pytest.mark.parametrize("n_end", [0, 1, 2, 8])
 def test_jacobi(shape: tuple[int, ...], n_end: int, xp: ArrayNamespaceFull) -> None:
     alpha = xp.random.random_uniform(low=0, high=5, shape=shape)
     beta = xp.random.random_uniform(low=0, high=5, shape=shape)
@@ -44,7 +44,7 @@ def test_jacobi(shape: tuple[int, ...], n_end: int, xp: ArrayNamespaceFull) -> N
         (3, 3, 4),
     ],
 )
-@pytest.mark.parametrize("n_end", [8])
+@pytest.mark.parametrize("n_end", [0, 1, 2, 8])
 def test_gegenbauer(shape: tuple[int, ...], n_end: int, xp: ArrayNamespaceFull) -> None:
     alpha = xp.random.random_uniform(low=0, high=5, shape=shape)
     x = xp.random.random_uniform(low=0, high=1, shape=shape)
@@ -65,7 +65,7 @@ def test_gegenbauer(shape: tuple[int, ...], n_end: int, xp: ArrayNamespaceFull) 
         (3, 3, 4),
     ],
 )
-@pytest.mark.parametrize("n_end", [8])
+@pytest.mark.parametrize("n_end", [0, 1, 2, 8])
 @pytest.mark.parametrize("type", ["gegenbauer", "jacobi"])
 def test_legendre(
     shape: tuple[int, ...],


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/34j/jacobi-poly/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/34j/jacobi-poly/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
